### PR TITLE
Add ability to use existing db struct

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -30,6 +30,14 @@ func NewHandler(driverName string, dataSourceName string, tableName string) (h *
 	return h, nil
 }
 
+func NewHandlerWithDB(driverName string, db *sql.DB, tableName string) *SQLHandler {
+	return &SQLHandler{
+		driverName: driverName,
+		session:    db,
+		tableName:  tableName,
+	}
+}
+
 func (h *SQLHandler) ExecContext(ctx context.Context, sqlQuery string, sqlParams ...interface{}) (sql.Result, error) {
 	return h.session.ExecContext(ctx, sqlQuery, sqlParams...)
 }


### PR DESCRIPTION
Sometimes the app will already have an existing db struct with additional settings apply to it. It may be useful to reuse that struct instead of creating a new one. This PR adds the ability to create a handler with an existing db struct.