### PR TITLE
Bugfix: Join all predicate expressions with AND

### DIFF
--- a/query.go
+++ b/query.go
@@ -142,7 +142,10 @@ func buildSortQuery(q *query.Query) (sqlQuery string, sqlParams []interface{}, e
 }
 
 func translatePredicate(q query.Predicate) (sqlQuery string, sqlParams []interface{}, err error) {
-	for _, exp := range q {
+	for i, exp := range q {
+		if i > 0 {
+			sqlQuery += " AND "
+		}
 		switch t := exp.(type) {
 		case *query.And:
 			var s string

--- a/query_test.go
+++ b/query_test.go
@@ -13,8 +13,14 @@ func TestTranslatePredicate(t *testing.T) {
 		sqlQuery string
 		sqlParams []interface{}
 	}{
+		// Bug: Assuming predicate will have always only one item
 		{
-			"{int: 1}", 
+			"{a: 1, b: 1}",
+			"a IS ?b IS ?",
+			[]interface{}{1.0, 1.0},
+		},
+		{
+			"{int: 1}",
 			"int IS ?",
 			[]interface{}{1.0},
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -13,10 +13,10 @@ func TestTranslatePredicate(t *testing.T) {
 		sqlQuery string
 		sqlParams []interface{}
 	}{
-		// Bug: Assuming predicate will have always only one item
+		// Regression Test: Predicate items must be joined with AND
 		{
 			"{a: 1, b: 1}",
-			"a IS ?b IS ?",
+			"a IS ? AND b IS ?",
 			[]interface{}{1.0, 1.0},
 		},
 		{


### PR DESCRIPTION
Predicate with multiple expressions works as logical AND group.
https://github.com/rs/rest-layer/blob/3f2cd5df9e8e6690c56f806710ef53048109c323/schema/query/predicate.go#L31-L43

#3 
https://github.com/rs/rest-layer/issues/245