### PR TITLE
Update query.go

### DIFF
--- a/query.go
+++ b/query.go
@@ -321,12 +321,19 @@ func transformParams_postgres(sqlParams []interface{}) ([]interface{}) {
 
 	for _,p := range sqlParams {
 		t := reflect.TypeOf(p)
-		switch t.Kind() {
-			case reflect.Slice, reflect.Array:
-				newSqlParams = append(newSqlParams, pq.Array(p))
-			default:
-				newSqlParams = append(newSqlParams, p)
-		} 
+		
+		if t == nil {
+			newSqlParams = append(newSqlParams, p)
+		} else {
+			switch t.Kind() {
+				case reflect.Slice, reflect.Array:
+					newSqlParams = append(newSqlParams, pq.Array(p))
+				default:
+					newSqlParams = append(newSqlParams, p)
+			} 
+		
+		}
+		
 	}
 
 	return newSqlParams


### PR DESCRIPTION
if the t is nil then t.Kind() returns panic
`panic: runtime error: invalid memory address or nil pointer dereference`
and we can not do a PATCH action